### PR TITLE
minor - prevents cljs compilation warning message

### DIFF
--- a/src/asami/core.cljc
+++ b/src/asami/core.cljc
@@ -41,6 +41,8 @@
           (reset! m {graph f})
           f)))))
 
+(declare ->MemoryStore)
+
 (defrecord MemoryStore [before-graph graph]
   Storage
   (start-tx [this] (->MemoryStore graph graph))


### PR DESCRIPTION
Prevents these warning lines during ClojureScript compilation:

```
WARNING: Use of undeclared Var asami.core/->MemoryStore at line 92 out/prod/asami/core.cljc
WARNING: Use of undeclared Var asami.core/->MemoryStore at line 103 out/prod/asami/core.cljc
WARNING: Use of undeclared Var asami.core/->MemoryStore at line 46 out/prod/asami/core.cljc
WARNING: Use of undeclared Var asami.core/->MemoryStore at line 89 out/prod/asami/core.cljc
```