### PR TITLE
Aggregates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
                  [prismatic/schema "1.1.12"] 
                  [org.clojure/core.cache "0.8.2"]
                  [org.clojars.quoll/naga-store "0.3.4"]]
-  :plugins [[lein-cljsbuild "1.1.7"]]
+  :plugins [[lein-cljsbuild "1.1.7"]
+            [cider/cider-nrepl "0.24.0"]]
   :cljsbuild {
     :builds {
       :dev

--- a/src/asami/core.cljc
+++ b/src/asami/core.cljc
@@ -132,9 +132,4 @@
 
 (s/defn q
   [query & inputs]
-  (let [{:keys [find in with where]} (-> (query/query-map query)
-                                         query/query-validator)
-        [bindings default-store] (query/create-bindings in inputs)
-        store (or default-store empty-store)
-        graph (or (:graph store) mem/empty-graph)]
-    (store-util/project store find (query/join-patterns graph where bindings))))
+  (query/query-entry query empty-store mem/empty-graph inputs))

--- a/src/asami/planner.cljc
+++ b/src/asami/planner.cljc
@@ -503,7 +503,7 @@
      (let [[maybe-op & args :as result] (sum-of-products (list* 'and patterns))]
        (if (= 'and maybe-op)
          args
-         [result])))))
+         (list result))))))
 
 (s/defn normalize-sum-of-products
   "Converts an expression that is not a sum into a sum operation of one argument."
@@ -512,7 +512,7 @@
     patterns
     (list 'or
           (if (= 1 (count patterns))
-            patterns
+            (first patterns)
             (list* 'and patterns)))))
 
 (s/defn minimal-first-planner :- [PatternOrBindings]

--- a/src/asami/planner.cljc
+++ b/src/asami/planner.cljc
@@ -557,9 +557,13 @@
               (vector? cnstrnt)
               (let [vars (get-vars cnstrnt)]
                 (when (or
-                       (and aggregating? (some aggregate-vars vars))
+                       (and aggregating?
+                            (or (some aggregate-vars vars)
+                                (nil? (some needed-vars vars))))
                        (and (not aggregating?)
-                            (or (nil? (some aggregate-vars vars)) (some needed-vars vars))))
+                            (some needed-vars vars)
+                            ;; (or (nil? (some aggregate-vars vars)) (some needed-vars vars))
+                            ))
                   cnstrnt))
 
               (seq? cnstrnt)

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -21,6 +21,8 @@
 
 (def ^:dynamic *select-distinct* distinct)
 
+(def ^:const identity-binding (with-meta [[]] {:cols []}))
+
 (s/defn find-vars [f] (set (filter st/vartest? f)))
 
 (defn op-error
@@ -398,7 +400,7 @@
                                                                patterns]
                                       ;; the first element is an operation,
                                       ;; start with an empty result and process all the patterns
-                                      :default [(with-meta [[]] {:cols []}) all-patterns])]
+                                      :default [identity-binding all-patterns])]
     ;; process the remaining query
     (reduce ljoin part-result proc-patterns)))
 
@@ -590,7 +592,7 @@
           ;; execute the outer queries
           outer-terms (filter vartest? find)
           ;; execute the outer query if it exists. If not then return an identity binding.
-          outer-results (map (fn [w] (if (seq w) (execute-query outer-terms w bindings graph project-fn) [[]])) outer-wheres)
+          outer-results (map (fn [w] (if (seq w) (execute-query outer-terms w bindings graph project-fn) identity-binding)) outer-wheres)
           ;; execute the inner queries within the context provided by the outer queries
           inner-results (mapcat (partial context-execute-query graph) outer-results inner-wheres)]
       ;; calculate the aggregates from the final results and project

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -582,17 +582,24 @@
   (binding [*select-distinct* distinct]
     ;; flatten the query
     (let [simplified (planner/simplify-algebra where)
+          ; _ (prn "simplified" simplified)
           ;; ensure that it is an (or ...) expression
           normalized (planner/normalize-sum-of-products simplified)
+          ; _ (prn "normalized" normalized)
           ;; extract every element of the or into an outer/inner pair of queries. The results zip
           [outer-wheres inner-wheres] (planner/split-aggregate-terms normalized find with)
+          ; _ (prn "outer-wheres" outer-wheres)
+          ; _ (prn "inner-wheres" inner-wheres)
           ;; outer wheres is a series of queries that make a sum (an OR operation). These all get run separately.
           ;; inner wheres is a matching series of queries that get run for the corresponding outer query.
 
           ;; execute the outer queries
           outer-terms (filter vartest? find)
+          ; _ (prn "outer-terms" outer-terms)
           ;; execute the outer query if it exists. If not then return an identity binding.
-          outer-results (map (fn [w] (if (seq w) (execute-query outer-terms w bindings graph project-fn) identity-binding)) outer-wheres)
+          project (fn [a b] b)
+          outer-results (map (fn [w] (if (seq w) (execute-query outer-terms w bindings graph project) identity-binding)) outer-wheres)
+          ; _ (prn "outer-results" outer-results)
           ;; execute the inner queries within the context provided by the outer queries
           inner-results (mapcat (partial context-execute-query graph) outer-results inner-wheres)]
       ;; calculate the aggregates from the final results and project

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -507,14 +507,50 @@
   "For each line in a context, execute a query specified by the where clause"
   [context :- Results
    where :- [Pattern]]
-  )
+  (let [context-cols (meta context)
+        subquery (fn [row]
+                   (run-simple-query
+                    graph
+                    (cons (with-meta [row] context-cols) where)))]
+    (map subquery context)))
+
+(def aggregate-fns
+  "Map of aggregate symbols to functions that accept a seq of data to be aggregated"
+  {'sum (partial apply sum)
+   'count count
+   'avg #(/ (apply sum %) (count %))
+   'max (partial apply max)
+   'min (partial apply min)
+   'first first})
+
+(s/defn result-label :- s/Symbol
+  "Convert an element from a select/find clause into an appropriate label"
+  [e]
+  (if (vartest? e)
+    e
+    (symbol (str "?" (name (first e)) "-" (subs (name (second e)) 1)))))
 
 (s/defn aggregate-over :- Results
   "For each seq of results, aggregates individually, and then together"
   [selection :- [s/Any]
    aggregates :- [Aggregate]
-   partial-results :- Results]
-  )
+   partial-results :- [Results]]
+  (letfn [(var-index [columns]
+            (into {} (map-indexed (fn [n c] [c n]) columns)))
+          (get-selectors [idxs]
+            (map (fn [s]
+                   (if (vartest? s)
+                     [first (var-index s)]
+                     [(aggregate-fns (first s)) (var-index (second s))]))
+                 selection))
+          (project-aggregate [result]
+            (let [idxs (var-index (:cols (meta result)))]
+              (for [[col-fn col-offset] (get-selectors idxs)]
+                (let [col-data (map #(nth % col-offset) result)]
+                  (col-fn col-data)))))]
+    (with-meta
+      (map project-aggregate partial-results)
+      {:cols (vec (map result-label selection))})))
 
 (s/defn query-entry
   "Main entry point of user queries"
@@ -535,7 +571,7 @@
               ;; execute the outer queries
               outer-results (map (fn [w] (when (seq w) (execute-query outer-terms w bindings graph store))) outer-wheres)
               ;; execute the inner queries within the context provided by the outer queries
-              inner-results (map context-execute-query outer-results inner-wheres)]
+              inner-results (mapcat (partial context-execute-query graph) outer-results inner-wheres)]
           ;; calculate the aggregates from the final results and project
           (aggregate-over find aggregates inner-results)))
       (binding [*select-distinct* (if all identity distinct)]

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -584,8 +584,12 @@
           normalized (planner/normalize-sum-of-products simplified)
           ;; extract every element of the or into an outer/inner pair of queries. The results zip
           [outer-wheres inner-wheres] (planner/split-aggregate-terms normalized find with)
+          ;; outer wheres is a series of queries that make a sum (an OR operation). These all get run separately.
+          ;; inner wheres is a matching series of queries that get run for the corresponding outer query.
+
           ;; execute the outer queries
           outer-terms (filter vartest? find)
+          ;; execute the outer query if it exists. If not then return an identity binding.
           outer-results (map (fn [w] (if (seq w) (execute-query outer-terms w bindings graph project-fn) [[]])) outer-wheres)
           ;; execute the inner queries within the context provided by the outer queries
           inner-results (mapcat (partial context-execute-query graph) outer-results inner-wheres)]

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -1,4 +1,4 @@
-(ns ^{:doc "Implements a full query engine based on fully indexed data."
+(ns ^{:doc "Implements query operations based on data accessible through the Graph protocol."
       :author "Paula Gearon"}
     asami.query
     (:require [naga.schema.store-structs :as st

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -586,8 +586,7 @@
           [outer-wheres inner-wheres] (planner/split-aggregate-terms normalized find with)
           ;; execute the outer queries
           outer-terms (filter vartest? find)
-          outer-results (map (fn [w] (when (seq w) (execute-query outer-terms w bindings graph project-fn))) outer-wheres)
-          ;; DEBUG: do outer results have columns?
+          outer-results (map (fn [w] (if (seq w) (execute-query outer-terms w bindings graph project-fn) [[]])) outer-wheres)
           ;; execute the inner queries within the context provided by the outer queries
           inner-results (mapcat (partial context-execute-query graph) outer-results inner-wheres)]
       ;; calculate the aggregates from the final results and project

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -521,7 +521,8 @@
         graph (or (:graph store) empty-graph)]
     (if-let [aggregates (seq (filter planner/aggregate-form? find))]
       (binding [*select-distinct* distinct]
-        (let [[outer-where inner-where] (planner/split-aggregate-terms where find with)
+        (let [simplified (planner/simplify-algebra where)
+              [outer-where inner-where] (planner/split-aggregate-terms where find with)
               outer-terms (remove (set aggregates) find)
               outer-result (execute-query outer-terms outer-where bindings graph store)]
           (aggregate-over aggregates with inner-where outer-result)))

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -618,7 +618,8 @@
                                  identity-binding))
                              outer-wheres inner-wheres)
           ;; execute the inner queries within the context provided by the outer queries
-          inner-results (mapcat (partial context-execute-query graph) outer-results inner-wheres)]
+          ;; remove the empty results. This means that empty values are not counted!
+          inner-results (filter seq (mapcat (partial context-execute-query graph) outer-results inner-wheres))]
       ;; calculate the aggregates from the final results and project
       (aggregate-over find inner-results))))
 

--- a/test/asami/test_core_query.cljc
+++ b/test/asami/test_core_query.cljc
@@ -451,7 +451,9 @@
       (is (= '[?count-child] (:cols (meta r4))))
       (is (= [[7]] r4))
       (is (= '[?parent ?count-child] (:cols (meta r5))))
-      (is (= [[pa 3] [pb 2] [pc 2]] r5))
+      (is (= #{[pa 3] [pb 2] [pc 2]} (set r5)))
+
+      ;; TODO: queries using WITH
       ))
 
  )

--- a/test/asami/test_core_query.cljc
+++ b/test/asami/test_core_query.cljc
@@ -437,6 +437,9 @@
           r4 (sq '[:find (count ?child)
                    :where
                    [?parent :child ?child]])
+          r5 (sq '[:find ?parent (count ?child)
+                   :where
+                   [?parent :child ?child]])
 
                 ]
       (is (= '[?count-person] (:cols (meta r1))))
@@ -447,21 +450,10 @@
       (is (= [[2]] r3))
       (is (= '[?count-child] (:cols (meta r4))))
       (is (= [[7]] r4))
+      (is (= '[?parent ?count-child] (:cols (meta r5))))
+      (is (= [[pa 3] [pb 2] [pc 2]] r5))
       ))
 
-  (deftest test-ag
-    (let [st (-> empty-store (assert-data data))
-          sq (fn [query] (q query st))
-
-          r3 (sq '[:find (count ?child)
-                   :where
-                   [?parent :name "Barbara"]
-                   [?parent :child ?child]])
-
-                ]
-      (is (= [[2]] r3))
-      ))
-  
  )
 
 #?(:cljs (run-tests))

--- a/test/asami/test_core_query.cljc
+++ b/test/asami/test_core_query.cljc
@@ -427,7 +427,7 @@
           sq (fn [query] (q query st))
 
           r1 (sq '[:find (count ?person)
-                  :where [?person :gender ?g]])
+                   :where [?person :gender ?g]])
           r2 (sq [:find '(count ?child)
                   :where [pb :child '?child]])
           r3 (sq '[:find (count ?child)
@@ -441,7 +441,18 @@
                    :where
                    [?parent :child ?child]])
 
-                ]
+          r6 (sq '[:find (count ?child)
+                   :where
+                   [?parent :gender ?f]
+                   [?f :label "female"]
+                   [?parent :child ?child]])
+          r7 (sq '[:find (count ?child)
+                   :with ?parent
+                   :where
+                   [?parent :gender ?f]
+                   [?f :label "female"]
+                   [?parent :child ?child]])
+          ]
       (is (= '[?count-person] (:cols (meta r1))))
       (is (= [[8]] r1))
       (is (= '[?count-child] (:cols (meta r2))))
@@ -452,11 +463,27 @@
       (is (= [[7]] r4))
       (is (= '[?parent ?count-child] (:cols (meta r5))))
       (is (= #{[pa 3] [pb 2] [pc 2]} (set r5)))
+      (is (= '[?count-child] (:cols (meta r6))))
+      (is (= [[5]] r6))
+      (is (= '[?count-child] (:cols (meta r7))))
+      (is (= #{[3] [2]} (set r7)))
 
-      ;; TODO: queries using WITH
       ))
 
- )
+  (deftest test-ag
+    (let [st (-> empty-store (assert-data data))
+          sq (fn [query] (q query st))
+
+          r6 (sq '[:find (count ?child)
+                   :where
+                   [?parent :gender ?f]
+                   [?f :label "female"]
+                   [?parent :child ?child]])
+          ]
+      (is (= '[?count-child] (:cols (meta r6))))
+      (is (= [[5]] r6))
+      ))
+  )
 
 #?(:cljs (run-tests))
 

--- a/test/asami/test_core_query.cljc
+++ b/test/asami/test_core_query.cljc
@@ -377,5 +377,92 @@
                ["Purely Functional Data Structures"]}
              (set r2))))))
 
+(let [pa (nn)
+      paa (nn)
+      pab (nn)
+      pac (nn)
+      pb (nn)
+      pba (nn)
+      pbb (nn)
+      pc (nn)
+      f (nn)
+      m (nn)
+
+      data [[pa :name "Alice"]
+            [pa :gender f]
+            [pa :child paa]
+            [pa :child pab]
+            [pa :child pac]
+            [paa :name "Antoine"]
+            [paa :age 16]
+            [paa :gender m]
+            [pab :name "Betty"]
+            [pab :age 14]
+            [pab :gender f]
+            [pac :name "Chuck"]
+            [pac :age 12]
+            [pac :gender m]
+
+            [pb :name "Barbara"]
+            [pb :gender f]
+            [pb :child pba]
+            [pb :child pbb]
+            [pba :name "Ann"]
+            [pba :age 13]
+            [pba :gender f]
+            [pbb :name "Bob"]
+            [pbb :age 11]
+            [pbb :gender m]
+
+            [pc :name "Cary"]
+            [pc :gender m]
+            [pc :child pba]
+            [pc :child pbb]
+
+            [f :label "female"]
+            [m :label "male"]]]
+
+  (deftest test-aggregates
+    (let [st (-> empty-store (assert-data data))
+          sq (fn [query] (q query st))
+
+          r1 (sq '[:find (count ?person)
+                  :where [?person :gender ?g]])
+          r2 (sq [:find '(count ?child)
+                  :where [pb :child '?child]])
+          r3 (sq '[:find (count ?child)
+                   :where
+                   [?parent :name "Barbara"]
+                   [?parent :child ?child]])
+          r4 (sq '[:find (count ?child)
+                   :where
+                   [?parent :child ?child]])
+
+                ]
+      (is (= '[?count-person] (:cols (meta r1))))
+      (is (= [[8]] r1))
+      (is (= '[?count-child] (:cols (meta r2))))
+      (is (= [[2]] r2))
+      (is (= '[?count-child] (:cols (meta r3))))
+      (is (= [[2]] r3))
+      (is (= '[?count-child] (:cols (meta r4))))
+      (is (= [[7]] r4))
+      ))
+
+  (deftest test-ag
+    (let [st (-> empty-store (assert-data data))
+          sq (fn [query] (q query st))
+
+          r3 (sq '[:find (count ?child)
+                   :where
+                   [?parent :name "Barbara"]
+                   [?parent :child ?child]])
+
+                ]
+      (is (= [[2]] r3))
+      ))
+  
+ )
+
 #?(:cljs (run-tests))
 

--- a/test/asami/test_planner.cljc
+++ b/test/asami/test_planner.cljc
@@ -365,7 +365,18 @@
     (is (= '[[?a :c :d] [?a :a :b] [(inc ?a) ?b] [?b :c :d] [?c :e ?b] [(identity ?c) ?e] (not [?e :s ?z] [?z :x :y])] p10))))
 
 (deftest test-algebra-flattening
-  (let [w1 (simplify-algebra '[[?a :p1 ?b] [?b :p2 ?c] (or [?c :p3 ?d] [?b :p3 ?d])])]
-    (is (= w1 '[(or (and [?a :p1 ?b] [?b :p2 ?c] [?c :p3 ?d]) (and [?a :p1 ?b] [?b :p2 ?c] [?b :p3 ?d]))]))))
+  (let [w1 (simplify-algebra '[[?a :p1 ?b] [?b :p2 ?c] (or [?c :p3 ?d] [?b :p3 ?d])])
+        w2 (simplify-algebra '[[?a :p1 ?b] [?b :p2 ?c] (or [?c :p3 ?d] [?b :p3 ?d]) [?d :z ?e]])
+        w3 (simplify-algebra '[[?a :p1 ?b] [?b :p2 ?c] (or (and [?c :p3 ?c2] [?c2 :px ?d]) [?b :p3 ?d])])
+        w4 (simplify-algebra '[[?a :p1 ?b] [?b :p2 ?c] (or (and [?c :p3 ?c2] (or [?c2 :px ?d] [?c2 :py ?d])) [?b :p3 ?d])])]
+    (is (= w1 '[(or (and [?a :p1 ?b] [?b :p2 ?c] [?c :p3 ?d])
+                    (and [?a :p1 ?b] [?b :p2 ?c] [?b :p3 ?d]))]))
+    (is (= w2 '[(or (and [?a :p1 ?b] [?b :p2 ?c] [?d :z ?e] [?c :p3 ?d])
+                    (and [?a :p1 ?b] [?b :p2 ?c] [?d :z ?e] [?b :p3 ?d]))]))
+    (is (= w3 '[(or (and [?a :p1 ?b] [?b :p2 ?c] [?c :p3 ?c2] [?c2 :px ?d])
+                    (and [?a :p1 ?b] [?b :p2 ?c] [?b :p3 ?d]))]))
+    (is (= w4 '[(or (and [?a :p1 ?b] [?b :p2 ?c] [?c :p3 ?c2] [?c2 :px ?d]) 
+                    (and [?a :p1 ?b] [?b :p2 ?c] [?c :p3 ?c2] [?c2 :py ?d])
+                    (and [?a :p1 ?b] [?b :p2 ?c] [?b :p3 ?d]))]))))
 
 #?(:cljs (run-tests))

--- a/test/asami/test_planner.cljc
+++ b/test/asami/test_planner.cljc
@@ -1,7 +1,8 @@
 (ns asami.test-planner
   "Tests internals of the query portion of the memory storage"
   (:require [asami.planner :refer [bindings-chain first-group min-join-path
-                                   plan-path merge-operations Bindings]]
+                                   plan-path merge-operations Bindings
+                                   simplify-algebra]]
             [asami.query]  ;; required, as this defines the HasVars protocol for objects
             [asami.graph :refer [Graph resolve-triple]]
             [naga.storage.store-util :refer [matching-vars]]
@@ -362,5 +363,9 @@
         p10 (plan-path test-graph test-patterns {})]
     ;; the [?a :a :b] constraint is promoted to second place because all its vars are already bound
     (is (= '[[?a :c :d] [?a :a :b] [(inc ?a) ?b] [?b :c :d] [?c :e ?b] [(identity ?c) ?e] (not [?e :s ?z] [?z :x :y])] p10))))
+
+(deftest test-algebra-flattening
+  (let [w1 (simplify-algebra '[[?a :p1 ?b] [?b :p2 ?c] (or [?c :p3 ?d] [?b :p3 ?d])])]
+    (is (= w1 '[(or (and [?a :p1 ?b] [?b :p2 ?c] [?c :p3 ?d]) (and [?a :p1 ?b] [?b :p2 ?c] [?b :p3 ?d]))]))))
 
 #?(:cljs (run-tests))

--- a/test/asami/test_query.cljc
+++ b/test/asami/test_query.cljc
@@ -297,9 +297,20 @@
           graph (add-to-graph empty-graph agg-data)
           project-fn (partial project empty-store)
 
-          r1 (aggregate-query find bindings with where graph project-fn)]
-      (is (= '[?a ?b ?count-c] (:cols (meta r1))))
-      (is (= [[:a "first" 3] [:b "second" 5]] r1)))))
+          r (aggregate-query find bindings with where graph project-fn)]
+      (is (= '[?a ?b ?count-c] (:cols (meta r))))
+      (is (= [[:a "first" 3] [:b "second" 5]] r)))
+
+    (let [find '[(count ?c)]
+          bindings q/empty-bindings
+          with []
+          where '[[?a :p ?c]]
+          graph (add-to-graph empty-graph agg-data)
+          project-fn (partial project empty-store)
+
+          r (aggregate-query find bindings with where graph project-fn)]
+      (is (= '[?count-c] (:cols (meta r))))
+      (is (= [[2]] r)))))
 
 #?(:clj
    (deftest test-eval

--- a/test/asami/test_query_internals.cljc
+++ b/test/asami/test_query_internals.cljc
@@ -1,4 +1,4 @@
-(ns asami.test-query
+(ns asami.test-query-internals
   "Tests internals of the query portion of the memory storage"
   (:require [asami.planner :refer [Bindings]]
             [asami.query :as q :refer [add-to-graph pattern-left-join outer-product


### PR DESCRIPTION
This addresses #3 and #4

Aggregating functions are now allowable in the `:find` clause, including a `count` function. Grouping can be accomplished using a `:with` clause