### PR TITLE
Fix bug with filter function construction

### DIFF
--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -5,7 +5,7 @@
                                    Results Value Var
                                    EvalPattern eval-pattern?
                                    epv-pattern? filter-pattern?
-                                   op-pattern? vars vartest?]]
+                                   op-pattern? vartest?]]
               [asami.planner :as planner :refer [Bindings PatternOrBindings Aggregate HasVars get-vars]]
               [asami.graph :as gr]
               [asami.internal :as internal]
@@ -22,7 +22,9 @@
 
 (def ^:const identity-binding (with-meta [[]] {:cols []}))
 
-(s/defn find-vars [f] (set (vars f)))
+(defn vars [s] (filter vartest? s))
+
+(defn find-vars [f] (set (vars f)))
 
 (defn op-error
   [pattern]

--- a/test/asami/test_api.cljc
+++ b/test/asami/test_api.cljc
@@ -326,7 +326,7 @@
                                         :movie/release-year 1995}]}))
       (is (= [["Explorers"]
               ["Toy Story"]]
-             (q '{:find ?name
+             (q '{:find [?name]
                   :where [[?m :movie/title ?name]
                           [?m :movie/genre ?genre]
                           [(re-find #"comedy|animation" ?genre)]]}

--- a/test/asami/test_api.cljc
+++ b/test/asami/test_api.cljc
@@ -309,4 +309,27 @@
     (is (= {:name "Anna" :age #{31 32} :aka ["Anitzka" "Annie" "Anne"] :friend ["Peter"] :husband {:db/ident :maksim}}
            (entity db2 :anna)))))
 
+(deftest test-filter-function
+  (testing "filter function is constructed properly"
+    (let [conn (connect "asami:mem://test8")]
+      (deref (transact conn {:tx-data [{:movie/title "Explorers"
+                                        :movie/genre "adventure/comedy/family"
+                                        :movie/release-year 1985}
+                                       {:movie/title "Demolition Man"
+                                        :movie/genre "action/sci-fi/thriller"
+                                        :movie/release-year 1993}
+                                       {:movie/title "Johnny Mnemonic"
+                                        :movie/genre "cyber-punk/action"
+                                        :movie/release-year 1995}
+                                       {:movie/title "Toy Story"
+                                        :movie/genre "animation/adventure"
+                                        :movie/release-year 1995}]}))
+      (is (= [["Explorers"]
+              ["Toy Story"]]
+             (q '{:find ?name
+                  :where [[?m :movie/title ?name]
+                          [?m :movie/genre ?genre]
+                          [(re-find #"comedy|animation" ?genre)]]}
+                (db conn)))))))
+
 #?(:cljs (run-tests))


### PR DESCRIPTION
The bug reported in #52 boils down to the index `0` being both a valid index into bindings and the static arguments passed to the filter function in the query i.e. both `#"foo"` and `?x` in

```clj
[?x _ ?s]
[(re-find #"foo" ?s)]
```

can calculate their respective indexes as `0` according to how we derive `arg-indexes`. `#"foo"` is the first static argument to `re-find` thus at index `0` by `(- 0)`. `?x` can also indexed to `0` by virtue of it being a variable and being assigned a natural number index. On `main` this is a problem because `(neg? 0)` is `false` and `neg?` is what is used to determine if the index is into the static arguments.

This patch fixes the issue with the encoding of static arguments such that arguments to the filter function are resolved properly.