### PR TITLE
Fix bug with explicit default graph

### DIFF
--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -423,9 +423,8 @@
         (throw (ex-info "In clause must not be more than the number of sources" {:in in :sources values})))
       (let [bindings (->> (map (fn [n v] (when-not (= '$ n) (create-binding n v))) in values)
                           (filter identity))
-            bindings (if (seq bindings)
-                       (reduce outer-product bindings)
-                       identity-binding)]
+            bindings (when (seq bindings)
+                       (reduce outer-product bindings))]
         [bindings default]))))
 
 (defn conforms? [t d]

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -389,9 +389,8 @@
         (throw (ex-info "Only one default data source permitted" {:defaults defaults})))
       (when-not (<= (count in) (count values))
         (throw (ex-info "In clause must not be more than the number of sources" {:in in :sources values})))
-      (let [bindings (->> (map (fn [n v] (when-not (= '$ n) [n v])) in values)
-                          (filter identity)
-                          (map (partial apply create-binding)))
+      (let [bindings (->> (map (fn [n v] (when-not (= '$ n) (create-binding n v))) in values)
+                          (filter identity))
             bindings (if (seq bindings)
                        (reduce outer-product bindings)
                        bindings)]

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -425,7 +425,7 @@
                           (filter identity))
             bindings (if (seq bindings)
                        (reduce outer-product bindings)
-                       bindings)]
+                       identity-binding)]
         [bindings default]))))
 
 (defn conforms? [t d]

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -389,11 +389,13 @@
         (throw (ex-info "Only one default data source permitted" {:defaults defaults})))
       (when-not (<= (count in) (count values))
         (throw (ex-info "In clause must not be more than the number of sources" {:in in :sources values})))
-      [(->> (map (fn [n v] (when-not (= '$ n) [n v])) in values)
-            (filter identity)
-            (map (partial apply create-binding))
-            (reduce outer-product))
-       default])))
+      (let [bindings (->> (map (fn [n v] (when-not (= '$ n) [n v])) in values)
+                          (filter identity)
+                          (map (partial apply create-binding)))
+            bindings (if (seq bindings)
+                       (reduce outer-product bindings)
+                       bindings)]
+        [bindings default]))))
 
 (defn conforms? [t d]
   (try

--- a/test/asami/test_api.cljc
+++ b/test/asami/test_api.cljc
@@ -398,4 +398,19 @@
                        [?e :is-in ?e2]
                        [?e :name "Washington Monument"]]}))))
 
+
+(deftest test-explicit-default-graph
+  (testing "explicity default graph"
+    (let [conn (connect "asami:mem://test10")]
+      (deref (transact conn {:tx-data [{:movie/title "Explorers"
+                                        :movie/genre "adventure/comedy/family"
+                                        :movie/release-year 1985}]}))
+      (is (= "Explorers"
+             (q '{:find [?name .]
+                  :in [$ ?release-year]
+                  :where [[?m :movie/title ?name]
+                          [?m :movie/release-year ?release-year]]}
+                  (db conn)
+                  1985))))))
+
 #?(:cljs (run-tests))

--- a/test/asami/test_api.cljc
+++ b/test/asami/test_api.cljc
@@ -407,10 +407,9 @@
                                         :movie/release-year 1985}]}))
       (is (= "Explorers"
              (q '{:find [?name .]
-                  :in [$ ?release-year]
+                  :in [$]
                   :where [[?m :movie/title ?name]
-                          [?m :movie/release-year ?release-year]]}
-                  (db conn)
-                  1985))))))
+                          [?m :movie/release-year 1985]]}
+                  (db conn)))))))
 
 #?(:cljs (run-tests))


### PR DESCRIPTION
This fixes the bug reported in #53 by preventing the wrong number of arguments being passed to reduce.