### PR TITLE
replace clojure.core/future with CompletableFuture

### DIFF
--- a/src/asami/core.cljc
+++ b/src/asami/core.cljc
@@ -1,22 +1,19 @@
 (ns ^{:doc "A storage implementation over in-memory indexing. Includes full query engine."
       :author "Paula Gearon"}
     asami.core
-  (:require [clojure.string :as str]
-            [asami.storage :as storage :refer [ConnectionType DatabaseType]]
-            [asami.memory :as memory]
-            [asami.query :as query]
-            [asami.internal :as internal]
-            [asami.datom :as datom :refer [->Datom]]
-            [asami.graph :as gr]
-            [zuko.util :as util]
-            [zuko.node :as node]
-            [zuko.entity.general :as entity :refer [EntityMap GraphType]]
-            [zuko.entity.writer :as writer :refer [Triple]]
-            [zuko.entity.reader :as reader]
-            #?(:clj  [schema.core :as s]
-               :cljs [schema.core :as s :include-macros true]))
-  #?(:clj (:import (java.util.concurrent CompletableFuture)
-                   (java.util.function Supplier))))
+    (:require [asami.storage :as storage :refer [ConnectionType DatabaseType]]
+              [asami.memory :as memory]
+              [asami.query :as query]
+              [asami.datom :as datom :refer [->Datom]]
+              [asami.graph :as gr]
+              [zuko.util :as util]
+              [zuko.node :as node]
+              [zuko.entity.general :as entity :refer [EntityMap GraphType]]
+              [zuko.entity.writer :as writer :refer [Triple]]
+              #?(:clj  [schema.core :as s]
+                 :cljs [schema.core :as s :include-macros true]))
+    #?(:clj (:import (java.util.concurrent CompletableFuture)
+                     (java.util.function Supplier))))
 
 (defonce connections (atom {}))
 
@@ -244,7 +241,8 @@
                     {(s/optional-key :tx-data) [s/Any]
                      (s/optional-key :tx-triples) [[(s/one s/Any "entity")
                                                     (s/one s/Any "attribute")
-                                                    (s/one s/Any "value")]]}
+                                                    (s/one s/Any "value")]]
+                     (s/optional-key :executor) s/Any}
                     [s/Any]))
 
 (s/defn transact
@@ -275,32 +273,30 @@
   :db-before    database value before the transaction
   :db-after     database value after the transaction
   :tx-data      sequence of datoms produced by the transaction
-  :tempids      mapping of the temporary IDs in entities to the allocated nodes"
-  ([connection tx-info]
-   (transact connection tx-info nil))
-  ([{:keys [name state] :as connection} :- ConnectionType
-    {:keys [tx-data tx-triples] :as tx-info} :- TransactData
-    {:keys [executor] :as options}]
-   (let [op (fn []
-              (let [tx-id (count (:history @state))
-                    as-datom (fn [assert? [e a v]] (->Datom e a v tx-id assert?))
-                    {:keys [graph history] :as db-before} (:db @state)
-                    [triples removals tempids] (if tx-triples ;; is this inserting raw triples?
-                                                 [tx-triples nil {}]
-                                                 ;; capture the old usage which didn't have an arg map
-                                                 (build-triples db-before (or tx-data tx-info)))
-                    [db-before db-after] (storage/transact-data connection triples removals)]
-                {:db-before db-before
-                 :db-after db-after
-                 :tx-data (concat
-                           (map (partial as-datom false) removals)
-                           (map (partial as-datom true) triples))
-                 :tempids tempids}))]
-     #?(:clj (CompletableFuture/supplyAsync (reify Supplier (get [_] (op)))
-                                            (or executor clojure.lang.Agent/soloExecutor))
-        :cljs (let [d (delay (op))]
-                (force d)
-                d)))))
+  :tempids      mapping of the temporary IDs in entities to the allocated nodes
+  :executor     Executor to be used to run the CompletableFuture"
+  [{:keys [name state] :as connection} :- ConnectionType
+   {:keys [tx-data tx-triples executor] :as tx-info} :- TransactData]
+  (let [op (fn []
+             (let [tx-id (count (:history @state))
+                   as-datom (fn [assert? [e a v]] (->Datom e a v tx-id assert?))
+                   {:keys [graph history] :as db-before} (:db @state)
+                   [triples removals tempids] (if tx-triples ;; is this inserting raw triples?
+                                                [tx-triples nil {}]
+                                                ;; capture the old usage which didn't have an arg map
+                                                (build-triples db-before (or tx-data tx-info)))
+                   [db-before db-after] (storage/transact-data connection triples removals)]
+               {:db-before db-before
+                :db-after db-after
+                :tx-data (concat
+                          (map (partial as-datom false) removals)
+                          (map (partial as-datom true) triples))
+                :tempids tempids}))]
+    #?(:clj (CompletableFuture/supplyAsync (reify Supplier (get [_] (op)))
+                                           (or executor clojure.lang.Agent/soloExecutor))
+       :cljs (let [d (delay (op))]
+               (force d)
+               d))))
 
 (defn- graphs-of
   "Converts Database objects to the graph that they wrap. Other arguments are returned unmodified."


### PR DESCRIPTION
First, thanks for the excellent library, it's really well done. 

From the commit msg: 
> This allows more composability between queries and also adds an `option` argument to transact that accepts an `:executor` key to control execution context. By default it will run on the same threadpool as clojure.core/future, `clojure.lang.Agent/soloExecutor`.

This should be backward compatible (java 9+) and open the door to better composability since cf has a very rich api: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html, you can register callbacks, error-handlers, do "select" execution, define max parallellism per executor and so on. 

There are a number of libraries in clojure that allow to work with these nicely (the java api is not too bad either)
ex: 
* https://github.com/mpenet/auspex/  (manifold copy-cat for completable-future)
* https://github.com/funcool/promesa 

CompletableFuture are also dereferable (they implement the java Future interface), so everything should just work like before otherwise. 


On a side note, the same could be done for cljs with js/Promise I think but I am not familiar with that one. 


