### PR TITLE
Support lookup refs in transactions

### DIFF
--- a/src/asami/entities.cljc
+++ b/src/asami/entities.cljc
@@ -121,6 +121,18 @@
   [i]
   (and (number? i) (neg? i)))
 
+(defn- lookup-ref?
+  "Tests if i is a lookup ref"
+  [i]
+  (and (vector? i)
+       (keyword? (first i))
+       (= 2 (count i))))
+
+(defn resolve-lookup-refs [graph i]
+  (if (lookup-ref? i)
+    (ffirst (gr/resolve-triple graph '?r (first i) (second i)))
+    i))
+
 (s/defn build-triples :- [(s/one [Triple] "Data to be asserted")
                           (s/one [Triple] "Data to be retracted")
                           (s/one {s/Any s/Any} "ID map of created objects")]
@@ -130,7 +142,8 @@
    data :- [s/Any]]
   (let [graph (storage/graph db)
         [retract-stmts new-data] (util/divide' #(= :db/retract (first %)) data)
-        retractions (mapv #(subvec % 1 4) retract-stmts)
+        ref->id (partial resolve-lookup-refs graph)
+        retractions (mapv #(into [(ref->id (second %))] (subvec % 2 4)) retract-stmts)
         add-triples (fn [[acc racc ids] obj]
                       (if (map? obj)
                         (let [[triples rtriples new-ids] (entity-triples graph obj ids)]
@@ -139,12 +152,12 @@
                                  (= 4 (count obj))
                                  (= :db/add (first obj)))
                           (or
-                           (if (= (nth obj 2) :db/id)
+                           (when (= (nth obj 2) :db/id)
                              (let [id (nth obj 3)]
-                               (if (temp-id? id)
+                               (when (temp-id? id)
                                  (let [new-id (or (ids id) (node/new-node graph))]
                                    [(conj acc (assoc (vec-rest obj) 2 new-id)) racc (assoc ids (or id new-id) new-id)]))))
-                           [(conj acc (mapv #(ids % %) (rest obj))) racc ids])
+                           [(conj acc (mapv #(or (ids %) (ref->id %)) (rest obj))) racc ids])
                           (throw (ex-info (str "Bad data in transaction: " obj) {:data obj})))))
         [triples rtriples id-map] (reduce add-triples [[] retractions {}] new-data)]
     [triples rtriples id-map]))

--- a/src/asami/entities.cljc
+++ b/src/asami/entities.cljc
@@ -143,7 +143,7 @@
   (let [graph (storage/graph db)
         [retract-stmts new-data] (util/divide' #(= :db/retract (first %)) data)
         ref->id (partial resolve-lookup-refs graph)
-        retractions (mapv #(into [(ref->id (second %))] (subvec % 2 4)) retract-stmts)
+        retractions (mapv (partial mapv ref->id) retract-stmts)
         add-triples (fn [[acc racc ids] obj]
                       (if (map? obj)
                         (let [[triples rtriples new-ids] (entity-triples graph obj ids)]

--- a/test/asami/api_test.cljc
+++ b/test/asami/api_test.cljc
@@ -163,6 +163,18 @@
       (is (= [[:mem/node-2 :property "other"]]
              (q '[:find ?e ?a ?v :where [?e ?a ?v]] (:db-after r2)))))))
 
+(deftest test-assertions-retractions-using-lookup-refs
+  (let [c (connect "asami:mem://testlr")
+        {d :db-after} @(transact c {:tx-data [{:db/ident "bobid"
+                                               :person/name "Bob"
+                                               :person/age 42}]})
+        bob (entity d "bobid")]
+    (is (= {:person/name "Bob" :person/age 42} bob))
+    (let [{d :db-after} @(transact c {:tx-data [[:db/add [:db/ident "bobid"] :person/street "First Street"]
+                                                [:db/retract [:db/ident "bobid"] :person/age 42]]})
+          bob (entity d "bobid")]
+      (is (= {:person/street "First Street" :person/name "Bob"} bob))))  )
+
 (deftest test-entity
   (let [c (connect "asami:mem://test4")
         maksim {:db/id -1
@@ -303,7 +315,7 @@
         db2* (since latest-db t2)  ;; after second tx
         db3* (since latest-db t3)  ;; well after second tx
         db0*' (since latest-db 0)  ;; after first tx
-        db1*' (since latest-db 1)  ;; after second tx 
+        db1*' (since latest-db 1)  ;; after second tx
         db2*' (since latest-db 2)  ;; still after second tx
         db3*' (since latest-db 3)] ;; still after second tx
     (is (= db0 db0'))


### PR DESCRIPTION
This adds support for using Datomic style [lookup refs](https://docs.datomic.com/on-prem/schema/identity.html#lookup-refs) in transactions, for example:
```clojure
[[:db/retract [:db/ident "bob"] :person/street "First Street"]
 [:db/retract [:db/ident "bob"] :person/age 42]]
```

I was also considering supporting lookup refs in the `:db/id` attribute in the map form like so 
```clojure
[{:db/id [:db/ident "bob"] :person/street "First Street"}]
```
but I'm unsure if that's a good idea as there is little to be gained over
```clojure
[{:db/ident "bob" :person/street "First Street"}]
```