### PR TITLE
Prevent in memory transact race condition

### DIFF
--- a/src/asami/memory.cljc
+++ b/src/asami/memory.cljc
@@ -149,16 +149,16 @@
   Returns a pair containing the old database and the new one."
   [conn :- ConnectionType
    update-fn :- (s/pred fn?)]
-  (let [next-state
-        (swap! (:state conn)
-               (fn [state]
-                 (let [{:keys [graph db history t] :as db-before} (:db state)
-                       next-tx (count (:history state))
-                       next-graph (update-fn graph next-tx)
-                       db-after (->MemoryDatabase next-graph (conj history db-before) (now) (inc t))]
-                   (with-meta {:db db-after :history (conj (:history db-after) db-after)}
-                     {:db-before db-before}))))]
-    [(:db-before (meta next-state)) (:db next-state)]))
+  (let [[{db-before :db} {db-after :db}]
+        (swap-vals! (:state conn)
+                    (fn [state]
+                      (let [{:keys [graph db history t] :as db-before} (:db state)
+                            next-tx (count (:history state))
+                            next-graph (update-fn graph next-tx)
+                            db-after (->MemoryDatabase next-graph (conj history db-before) (now) (inc t))]
+                        {:db db-after
+                         :history (conj (:history db-after) db-after)})))]
+    [db-before db-after]))
 
 (s/defn transact-data* :- [(s/one DatabaseType "The database before the operation")
                            (s/one DatabaseType "The database after the operation")]

--- a/test/asami/race_condition_test.clj
+++ b/test/asami/race_condition_test.clj
@@ -1,0 +1,16 @@
+(ns asami.race-condition-test
+  (:require [asami.core :as asami]
+            [clojure.test :as t]))
+
+(t/deftest race-condition-test
+  (let [db (asami/connect (str "asami:mem://" (gensym)))
+        numbers (mapv (fn [n] {:n n}) (range 100))]
+    (run!
+     (fn [tx-data]
+       (asami/transact db {:tx-data tx-data}))
+     (partition 10 numbers))
+
+    (Thread/sleep 1000)
+
+    (t/is (= 100
+             (count (asami/q '{:find [?n], :where [[_ :n ?n]]} (asami/db db)))))))


### PR DESCRIPTION
This patch prevents a race condition that can occur when multiple transactions are executed concurrently.

Previously the in memory implementation of `transact-update*` would get `db-before` and the next `tx-id` via `db*` and `next-tx*` respectively. Both of these functions read data out of the connection state, an atom. When called concurrently, this can be problematic because both values are used to determine what is written to the state and may be stale by that time causing successive transactions to clobber one another.

To solve this problem we use `swap!` to ensure the both the current state of the database and history are read at the time of writing.