### PR TITLE
Added support for :id

### DIFF
--- a/src/asami/durable/store.cljc
+++ b/src/asami/durable/store.cljc
@@ -124,9 +124,7 @@
   [{bgraph :bgraph :as database}
    id
    nested? :- s/Bool]
-  (when-let [ref (or (and (seq (graph/resolve-triple bgraph id '?a '?v)) id)
-                   (ffirst (graph/resolve-triple bgraph '?e :db/ident id)))]
-    (reader/ref->entity bgraph ref nested?)))
+  (reader/ident->entity bgraph id nested?))
 
 (defrecord DurableDatabase [connection bgraph t timestamp]
   storage/Database

--- a/src/asami/entities/reader.cljc
+++ b/src/asami/entities/reader.cljc
@@ -35,7 +35,7 @@
   [graph :- GraphType
    prop :- s/Any
    v :- s/Any]
-  (if (and (not (#{:db/ident :db/id} prop)) (node/node-type? graph prop v))
+  (when (and (not (#{:db/ident :db/id} prop)) (node/node-type? graph prop v))
     (let [data (property-values graph v)]
       data)))
 
@@ -80,8 +80,8 @@
    [prop v :as prop-val] :- KeyValue]
   (if-let [pairs (check-structure graph prop v)]
     (if (and (not *nested-structs*) (some #(= :tg/entity (first %)) pairs))
-      [prop (if-let [ident (some (fn [[k v]] (if (= :db/ident k) v)) pairs)]
-              {:db/ident ident}
+      [prop (if-let [[idd ident] (some (fn [[k v]] (if (#{:db/ident :id} k) [k v])) pairs)]
+              {idd ident}
               {:db/id v})]
       [prop (or (vbuild-list graph seen pairs)
                 (pairs->struct graph pairs (conj seen v)))])
@@ -162,7 +162,8 @@
    ;; find the entity by its ident. Some systems will make the id the entity id,
    ;; and the ident will be separate, so look for both.
    (let [eid (or (ffirst (node/find-triple graph [ident '?a '?v]))
-                 (ffirst (node/find-triple graph ['?eid :db/ident ident])))]
+                 (ffirst (node/find-triple graph ['?eid :db/ident ident]))
+                 (ffirst (node/find-triple graph ['?eid :id ident])))]
      (ref->entity graph eid nested?))))
 
 (s/defn graph->entities :- [EntityMap]

--- a/src/asami/entities/reader.cljc
+++ b/src/asami/entities/reader.cljc
@@ -160,10 +160,10 @@
     ident :- s/Any
     nested? :- s/Bool]
    ;; find the entity by its ident. Some systems will make the id the entity id,
-   ;; and the ident will be separate, so look for both.
-   (let [eid (or (ffirst (node/find-triple graph [ident '?a '?v]))
-                 (ffirst (node/find-triple graph ['?eid :db/ident ident]))
-                 (ffirst (node/find-triple graph ['?eid :id ident])))]
+   ;; and the ident will be separate, so look for both. Also supporting lookup by :id
+   (when-let [eid (or (and (seq (node/find-triple graph [ident '?a '?v])) ident)
+                      (ffirst (node/find-triple graph ['?eid :db/ident ident]))
+                      (ffirst (node/find-triple graph ['?eid :id ident])))]
      (ref->entity graph eid nested?))))
 
 (s/defn graph->entities :- [EntityMap]

--- a/src/asami/memory.cljc
+++ b/src/asami/memory.cljc
@@ -179,12 +179,10 @@
                          (gr/graph-transact graph tx-id asserts retracts))))))
 
 
-(s/defn entity* :- {s/Any s/Any}
+(s/defn entity* :- (s/maybe {s/Any s/Any})
   "Returns an entity based on an identifier, either the :db/id or a :db/ident if this is available. This eagerly retrieves the entity.
    Objects may be nested, but references to top level objects will be nil in order to avoid loops."
   ;; TODO Reference the up-coming entity index
   [{graph :graph :as db} id nested?]
-  (if-let [ref (or (and (seq (gr/resolve-triple graph id '?a '?v)) id)
-                   (ffirst (gr/resolve-triple graph '?e :db/ident id)))]
-    (reader/ref->entity graph ref nested?)))
+  (reader/ident->entity graph id nested?))
 

--- a/test/asami/api_test.cljc
+++ b/test/asami/api_test.cljc
@@ -194,6 +194,7 @@
   (let [c (connect "asami:mem://test4")
         maksim {:db/id -1
                 :db/ident :maksim
+                :id    "MakOvS"
                 :name  "Maksim"
                 :age   45
                 :aka   ["Maks Otto von Stirlitz", "Jack Ryan"]}
@@ -214,14 +215,21 @@
         two (tempids -2)
         three (tempids -3)
         d (db c)]
-    (is (= {:name  "Maksim"
+    (is (= {:id    "MakOvS"
+            :name  "Maksim"
             :age   45
             :aka   ["Maks Otto von Stirlitz", "Jack Ryan"]}
            (entity d one)))
-    (is (= {:name  "Maksim"
+    (is (= {:id    "MakOvS"
+            :name  "Maksim"
             :age   45
             :aka   ["Maks Otto von Stirlitz", "Jack Ryan"]}
            (entity d :maksim)))
+    (is (= {:id    "MakOvS"
+            :name  "Maksim"
+            :age   45
+            :aka   ["Maks Otto von Stirlitz", "Jack Ryan"]}
+           (entity d "MakOvS")))
     (is (= {:name  "Anna"
             :age   31
             :husband {:db/ident :maksim}

--- a/test/asami/entities/test_entity.cljc
+++ b/test/asami/entities/test_entity.cljc
@@ -271,7 +271,7 @@
         graph (assert-data graph' [[ref "Connected_To" ref]])
         obj1 (ref->entity graph ref)
         obj2 (ref->entity graph ref false #{"Connected_To"})]
-    (is (= (assoc data "Connected_To" {:db/ident ref})
+    (is (= (assoc data "Connected_To" {:id "1234"})
            obj1))
     (is (= data obj2))))
 


### PR DESCRIPTION
The `:id` field is now a valid referring identified. Similar to `:db/ident`, but it will not be autogenerated, and it is not removed from entities when they are returned.