### PR TITLE
Read queries with edn/read; Initial work on basic interactivity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,10 @@
                                           "--initialize-at-build-time" "--no-server"
                                           "-jar" "./target/${:uberjar-name:-${:name}-${:version}-standalone.jar}"
                                           "-H:Name=./target/${:name}"
-                                          "-H:TraceClassInitialization=\"java.io.FilePermission\""]}}}
+                                          "-H:TraceClassInitialization=\"java.io.FilePermission\""]}}
+             :test-native {:source-paths ["src" "src-native" "test-native"]
+                           :test-paths ["test-native"]
+                           :dependencies [[cheshire "5.10.0"]]}}
   :cljsbuild {:builds {:dev {:source-paths ["src"]
                              :compiler {:output-to "out/asami/core.js"
                                         :optimizations :simple

--- a/src-native/asami/main.clj
+++ b/src-native/asami/main.clj
@@ -12,7 +12,7 @@
   (:gen-class))
 
 (def eof
-  (reify))
+  (Object.))
 
 (defn eof? [x]
   (identical? x eof))

--- a/src-native/asami/main.clj
+++ b/src-native/asami/main.clj
@@ -22,22 +22,14 @@
 (defn process-args
   [args]
   (loop [opts default-opts
-         [a & [arg & rargs :as rem] :as args] args]
+         [a & [arg & rargs :as rem]] args]
     (if-not (seq args)
       opts
       (let [[r more] (case a
-                       ("-e" "-q")
-                       [(assoc opts :query arg) rargs]
-
-                       "-f"
-                       [(assoc opts :file arg) rargs]
-
-                       ("-?" "--help")
-                       [(assoc opts :help true) rem]
-
-                       ("--interactive")
-                       [(assoc opts :interactive? true) rem]
-
+                       ("-e" "-q") [(assoc opts :query arg) rargs]
+                       "-f" [(assoc opts :file arg) rargs]
+                       ("-?" "--help") [(assoc opts :help true) rem]
+                       ("--interactive") [(assoc opts :interactive? true) rem]
                        ;; else
                        (if (s/starts-with? a "asami:")
                          [(assoc opts :url a) rem]))]

--- a/src-native/asami/main.clj
+++ b/src-native/asami/main.clj
@@ -14,6 +14,9 @@
 (def eof
   (reify))
 
+(defn eof? [x]
+  (identical? x eof))
+
 (def reader-opts
   {:eof eof
    :readers (assoc graph/node-reader 'a/r re-pattern)})

--- a/test-native/asami/main_test.clj
+++ b/test-native/asami/main_test.clj
@@ -1,0 +1,85 @@
+(ns asami.main-test
+  (:require [asami.main :as native]
+            [asami.core :as asami]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.test :as t])
+  (:import (java.io File)
+           (java.io PushbackReader)))
+
+(t/deftest process-args-test
+  (let [url "asami:"
+        query "[:find ?x :where [?x ?y ?z]]"
+        filename "foo.edn"]
+    (t/is (= (native/process-args [])
+             {:interactive? false
+              :query "-"}))
+
+    (t/is (= {:interactive? true
+              :query "-"}
+             (native/process-args ["--interactive"])))
+
+    (t/is (= {:help true
+              :interactive? false
+              :query "-"}
+             (native/process-args ["-?"])))
+
+    (t/is (= {:help true
+              :interactive? false
+              :query "-"}
+             (native/process-args ["--help"])))
+
+    (t/is (= {:interactive? false
+              :query "-"
+              :url url}
+             (native/process-args [url])))
+
+    (t/is (= {:interactive? false
+              :query query
+              :url url}
+             (native/process-args [url "-q" query])
+             (native/process-args [url "-q" query])))
+    
+    (t/is (= {:file "foo.edn"
+              :interactive? false
+              :query query
+              :url url}
+             (native/process-args [url "-e" query "-f" filename])))))
+
+(defmacro repl-out-str
+  "Macro to help test asami.main/repl."
+  [& args]
+  `(with-out-str (native/repl ~@args)))
+
+(t/deftest repl-test
+  (let [conn (asami/connect (str "asami:mem://" (gensym)))
+        tx-triples [["alice" :knows "bob"]
+                    ["bob" :knows "alice"]]
+        _ (deref (asami/transact conn {:tx-triples tx-triples}))
+        db (asami/db conn)]
+    (t/testing "one map query"
+      (let [query "{:find [?x ?y] :where [[?x :knows ?y]]}"
+            result (edn/read-string (repl-out-str (native/derive-stream {:query query}) db nil))
+            result-set (into #{} result)]
+        (t/is (= #{["alice" "bob"] ["bob" "alice"]}
+                 result-set))))
+
+    (t/testing "one vector query"
+      (let [query "[:find ?x ?y :where [?x :knows ?y]]"
+            result (edn/read-string (repl-out-str (native/derive-stream {:query query}) (asami/db conn) nil))
+            result-set (into #{} result)]
+        (t/is (= #{["alice" "bob"] ["bob" "alice"]}
+                 result-set))))
+
+    (t/testing "multiple queries"
+      (let [query "{:find [?x] :where [[\"alice\" :knows ?x]]}
+                   {:find [?x] :where [[\"bob\" :knows ?x]]}"
+            result (repl-out-str (native/derive-stream {:query query}) (asami/db conn) nil)
+            stream (PushbackReader. (io/reader (.getBytes result)))]
+        (t/is (= #{[["alice"]] [["bob"]]} (conj #{} (edn/read stream) (edn/read stream))))))
+
+    (let [query "{:find [?x ?y] :where [[?x :knows ?y]]"
+          stream (native/derive-stream {:query query})
+          result (repl-out-str stream (asami/db conn) nil)]
+      (t/is (= result "Error: EOF while reading\n")))))
+


### PR DESCRIPTION
### Overview

The interactivity is _basic_ and works a bit like the following.

```
$ asami asami:mem://db -f db.edn --interactive
?- [:find ?x :where [_ _ ?x]]
(["bob"] ,,,)
?- ^D
$ echo $?
0
```

I refactored the code a bit so that whether the application is executing queries from `*in*`, from `-e <QUERY>`, or interactively via `--interactive`, it uses the same machinery: the `repl` function. This is because the only difference between executing the application with the former two and the latter is the presence of a prompt.

Here is an example piping in some queries.

```
$ cat queries.asami | lein with-profile native run -- asami:mem://db -f db.edn
(["bob"] ,,,)
([:knows] ,,,)
([:tg/node-162] ,,,)
```
where the file `queries.asami` has the following content.
```
[:find ?x :where [_ _ ?x]] ; [:find ?y :where [_ ?y _]]

[:find ?z :where [?z _ _]]
```

The same behavior can be observed by running the application interactively.

```
$ lein with-profile native run -- asami:mem://db -f db.edn --interactive
?-  [:find ?x :where [_ _ ?x]] ; [:find ?y :where [_ ?y _]]
(["bob"] ,,,)
([:knows] ,,,)
?-  [:find ?z :where [?z _ _]]
([:tg/node-162] ,,,)
```

---

### Some thoughts

I think we can reduce the complexity of the reader code if we accept queries as we typically do in the library e.g. `[:find ?x ,,,]` or `{:find [?x] ,,,}`. Since we're using `edn/read`, queries can be separated with white space (including `,`) and `;` can still be used for comments. This would make it easy to author queries in an `.edn` file (and such a file could also be accepted on the command line ie. `-q queries.edn`). In summary, I think we should treat input as a script written in EDN.

Also, I was confused by [this line](https://github.com/threatgrid/asami/blob/main/src-native/asami/main.clj#L42):

```clj
(let [txt (if (= \: (first (s/trim text))) (str "[" text "]") text)]
   (edn/read-string reader-opts txt))
```

What is this intended for?

Finally, what do you think about leveraging `clojure.tools.cli` for processing the command line arguments?