### PR TITLE
Store transaction values in in-memory indexes

### DIFF
--- a/src/asami/common_index.cljc
+++ b/src/asami/common_index.cljc
@@ -68,7 +68,7 @@ and multigraph implementations."
 (defn check-for-transitive
   "Tests if a predicate is transitive.
   Returns a plain version of the predicate, along with a value to indicate if the predicate is transitive.
-  This value is nil for a plan predicate, or else is a keyword to indicate the kind of transitivity."
+  This value is nil for a plain predicate, or else is a keyword to indicate the kind of transitivity."
   [pred]
   (let [{trans? :trans :as meta-pred} (meta pred)
         not-trans? (and (contains? meta-pred :trans) (not trans?))

--- a/src/asami/common_index.cljc
+++ b/src/asami/common_index.cljc
@@ -275,11 +275,16 @@ and multigraph implementations."
 (def get-transitive-edges
   (internal/shallow-cache-1 transitive-cache-depth get-transitive-edges*))
 
+(defn create-o->smap
+  "produces a map from objects to subjects for existing edges in the graph
+  for a given predicate"
+  [{idx :pos :as graph} p]
+  ((mid-level-map-fn graph) (idx p)))
+
 ;; every node that can reach every node with just a predicate
 (defmethod get-transitive-from-index [ ? :v  ?]
   [{idx :pos :as graph} tag s p o]
-  (let [o->s-map-fn (mid-level-map-fn graph)
-        o->s-map (o->s-map-fn (idx p))
+  (let [o->s-map (create-o->smap graph p)
         result-index (get-transitive-edges o->s-map)
         result-index (if (= :star tag)
                        (add-zero-step o->s-map result-index)
@@ -290,7 +295,7 @@ and multigraph implementations."
 ;; finds all transitive paths that end at a node
 (defmethod get-transitive-from-index [ ? :v :v]
   [{idx :pos :as graph} tag s p o]
-  (let [o->s-map ((mid-level-map-fn graph) (idx p))
+  (let [o->s-map (create-o->smap graph p)
         trans-closure (get-transitive-edges o->s-map)
         nodes (trans-closure o)]
     (zero-step tag [o] (map vector nodes))))
@@ -298,7 +303,7 @@ and multigraph implementations."
 ;; follows a predicate transitively from a node
 (defmethod get-transitive-from-index [:v :v  ?]
   [{idx :pos :as graph} tag s p o]
-  (let [o->s-map ((mid-level-map-fn graph) (idx p))
+  (let [o->s-map (create-o->smap graph p)
         trans-closure (get-transitive-edges o->s-map)
         nodes (for [[o' ss] trans-closure :when (contains? ss s)] [o'])]
     (zero-step tag [s] nodes)))

--- a/src/asami/common_index.cljc
+++ b/src/asami/common_index.cljc
@@ -276,8 +276,8 @@ and multigraph implementations."
   (internal/shallow-cache-1 transitive-cache-depth get-transitive-edges*))
 
 (defn create-o->smap
-  "produces a map from objects to subjects for existing edges in the graph
-  for a given predicate"
+  "Produces a map from objects to subjects for existing edges in the graph
+  for a given predicate."
   [{idx :pos :as graph} p]
   ((mid-level-map-fn graph) (idx p)))
 

--- a/src/asami/index.cljc
+++ b/src/asami/index.cljc
@@ -18,8 +18,8 @@
    a :- s/Any
    b :- s/Any
    c :- s/Any
-   t :- s/Int
-   id :- s/Int]
+   id :- s/Int
+   t :- s/Int]
   (if-let [idxb (get idx a)]
     (if-let [idxc (get idxb b)]
       (if (get idxc c)
@@ -88,14 +88,14 @@
   (graph-add [this subj pred obj tx]
     (log/trace "insert: " [subj pred obj tx])
     (let [id (or (:next-stmt-id this) 1)
-          new-spo (index-add spo subj pred obj tx id)]
+          new-spo (index-add spo subj pred obj id tx)]
       (if (identical? spo new-spo)
         (do
           (log/trace "statement already existed")
           this)
         (assoc this :spo new-spo
-               :pos (index-add pos pred obj subj tx id)
-               :osp (index-add osp obj subj pred tx id)
+               :pos (index-add pos pred obj subj id tx)
+               :osp (index-add osp obj subj pred id tx)
                :next-stmt-id (inc id)))))
   (graph-delete [this subj pred obj]
     (log/trace "delete " [subj pred obj])

--- a/src/asami/index.cljc
+++ b/src/asami/index.cljc
@@ -33,7 +33,7 @@
    c :- s/Any]
   (if-let [idx2 (idx a)]
     (if-let [idx3 (idx2 b)]
-      (let [new-idx3 (disj idx3 c)]
+      (let [new-idx3 (dissoc idx3 c)]
         (if-not (identical? new-idx3 idx3)
           (let [new-idx2 (if (seq new-idx3) (assoc idx2 b new-idx3) (dissoc idx2 b))
                 new-idx (if (seq new-idx2) (assoc idx a new-idx2) (dissoc idx a))]

--- a/src/asami/index.cljc
+++ b/src/asami/index.cljc
@@ -73,10 +73,10 @@
 
 (defrecord GraphIndexed [spo pos osp]
   NestedIndex
-  (lowest-level-fn [this] identity)
-  (lowest-level-sets-fn [this] identity)
-  (lowest-level-set-fn [this] identity)
-  (mid-level-map-fn [this] identity)
+  (lowest-level-fn [this] keys)
+  (lowest-level-sets-fn [this] (partial map (comp set keys)))
+  (lowest-level-set-fn [this] (comp set keys))
+  (mid-level-map-fn [this]  #(into {} (map (fn [[k v]] [k (set (keys v))]) %1)))
 
   Graph
   (new-graph [this] empty-graph)

--- a/src/asami/index.cljc
+++ b/src/asami/index.cljc
@@ -53,7 +53,7 @@
 (defmethod get-from-index [:v :v  ?] [{idx :spo} s p o] (map vector (some-> idx (get s) (get p) keys)))
 (defmethod get-from-index [:v  ? :v] [{idx :osp} s p o] (map vector (some-> idx (get o) (get s) keys)))
 (defmethod get-from-index [:v  ?  ?] [{idx :spo} s p o] (let [edx (idx s)] (for [p (keys edx) o ((comp keys edx) p)] [p o])))
-(defmethod get-from-index [ ? :v :v] [{idx :pos} s p o] (map vector (some-> idx (get p) (get o) (keys))))
+(defmethod get-from-index [ ? :v :v] [{idx :pos} s p o] (map vector (some-> idx (get p) (get o) keys)))
 (defmethod get-from-index [ ? :v  ?] [{idx :pos} s p o] (let [edx (idx p)] (for [o (keys edx) s ((comp keys edx) o)] [s o])))
 (defmethod get-from-index [ ?  ? :v] [{idx :osp} s p o] (let [edx (idx o)] (for [s (keys edx) p ((comp keys edx) s)] [s p])))
 (defmethod get-from-index [ ?  ?  ?] [{idx :spo} s p o] (for [s (keys idx) p (keys (idx s)) o (keys ((idx s) p))] [s p o]))
@@ -74,12 +74,12 @@
 
 (declare empty-graph)
 
-(defrecord GraphIndexed [spo pos osp]
+(defrecord GraphIndexed [spo pos osp next-stmt-id]
   NestedIndex
   (lowest-level-fn [this] keys)
   (lowest-level-sets-fn [this] (partial map (comp set keys)))
   (lowest-level-set-fn [this] (comp set keys))
-  (mid-level-map-fn [this]  #(into {} (map (fn [[k v]] [k (set (keys v))]) %1)))
+  (mid-level-map-fn [this]  #(into {} (map (fn [[k v]] [k (set (keys v))]) %)))
 
   Graph
   (new-graph [this] empty-graph)
@@ -133,4 +133,4 @@
   (node-type? [_ _ n] (gr/node-type? n))
   (find-triple [this [e a v]] (resolve-triple this e a v)))
 
-(def empty-graph (->GraphIndexed {} {} {}))
+(def empty-graph (->GraphIndexed {} {} {} nil))

--- a/test/asami/memory_index_test.cljc
+++ b/test/asami/memory_index_test.cljc
@@ -22,8 +22,11 @@
    [:b :p3 :z]
    [:c :p4 :t]])
 
-(defn assert-data [g d]
-  (reduce (fn [g [s p o]] (graph-add g s p o 1)) g d))
+(defn assert-data
+  ([g d]
+   (assert-data g d 1))
+  ([g d tx]
+   (reduce (fn [g [s p o]] (graph-add g s p o tx)) g d)))
 
 (defn unordered-resolve
   [g pattern]
@@ -80,4 +83,27 @@
     (is (= 8 r9))))
 
 #?(:cljs (run-tests))
+
+(deftest test-txn-values
+  (let [g (-> empty-graph
+              (assert-data (take 2 data) 1)
+              (assert-data (drop 2 data) 2))
+        last-stmt-id (count data)]
+    (is (= (inc last-stmt-id) (:next-stmt-id g)))
+    ;; TODO use actual queries instead once they're supported
+    (is (= 1 (get-in g [:spo :a :p1 :y :t])))
+    (is (= 1 (get-in g [:osp :y :a :p1 :t])))
+    (is (= 1 (get-in g [:pos :p1 :y :a :t])))
+
+    (is (= 2 (get-in g [:spo :c :p4 :t :t])))
+    (is (= 2 (get-in g [:osp :t :c :p4 :t])))
+    (is (= 2 (get-in g [:pos :p4 :t :c :t])))
+
+    (is (= 1 (get-in g [:spo :a :p1 :x :id])))
+    (is (= 1 (get-in g [:osp :x :a :p1 :id])))
+    (is (= 1 (get-in g [:pos :p1 :x :a :id])))
+
+    (is (= last-stmt-id (get-in g [:spo :c :p4 :t :id])))
+    (is (= last-stmt-id (get-in g [:osp :t :c :p4 :id])))
+    (is (= last-stmt-id (get-in g [:pos :p4 :t :c :id])))))
 

--- a/test/asami/transitive_test.cljc
+++ b/test/asami/transitive_test.cljc
@@ -5,7 +5,7 @@
             [asami.graph :refer [Graph graph-add resolve-pattern]]
             [asami.index :refer [empty-graph]]
             [asami.multi-graph :refer [empty-multi-graph]]
-            [asami.common-index :refer [step-by-predicate]]
+            [asami.common-index :refer [step-by-predicate create-o->smap]]
             #?(:clj  [schema.core :as s]
                :cljs [schema.core :as s :include-macros true])
             #?(:clj  [clojure.test :refer [is use-fixtures testing]]
@@ -385,7 +385,8 @@
 (deftest test-network-closure
   (let [g (assert-data empty-graph regions)
         non-trans (unordered-resolve g '[?a :n ?b])
-        step1 (step-by-predicate (:n (:pos g)))
+        o->smap (create-o->smap g :n)
+        step1 (step-by-predicate o->smap)
         step2 (step-by-predicate step1)
         step3 (step-by-predicate step2)
         r1 (unordered-resolve g '[?a :n+ ?b])
@@ -393,7 +394,7 @@
         locations (-> #{} (into (map first regions)) (into (map #(nth % 2) regions)))
         zeros (map (fn [a] [a a]) locations)]
     (is (= non-trans (set (map (fn [[a _ b]] [a b]) regions))))
-    (is (= non-trans (spairs (:n (:pos g)))))
+    (is (= non-trans (spairs o->smap)))
     
     (is (every? (spairs step1) non-trans))
     (is (every? (spairs step2) (spairs step1)))


### PR DESCRIPTION
Closes #198 

Adds transaction values (`:t`) and statement ids (`:id`) to each statement in the in-memory indexes.

Transaction values were already being provided and ignored, this PR just updates the in-memory indexes to actually store them.

Statement ids are generated upon insertion of statements, and are unique per statement for a given graph.