### PR TITLE
Add statement ids, transaction t values to multi_index

### DIFF
--- a/test/asami/entities/test_entity.cljc
+++ b/test/asami/entities/test_entity.cljc
@@ -405,22 +405,22 @@
         #asami.multi_graph.MultiGraph{:spo #:tg{:node-27367
                                                 {:db/ident #:tg{:node-27367 {:count 1 :t 0 :id 1}},
                                                  :tg/entity {true {:count 1 :t 0 :id 2}},
-                                                 :value {"01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9" {:count 1 :t 0 :id 1}},
-                                                 :type {"sha256" {:count 1 :t 0 :id 3}},
-                                                 :id {"4f390192" {:count 1 :t 0 :id 4}}}},
+                                                 :value {"01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9" {:count 1 :t 0 :id 3}},
+                                                 :type {"sha256" {:count 1 :t 0 :id 4}},
+                                                 :id {"4f390192" {:count 1 :t 0 :id 5}}}},
                                       :pos {:db/ident
-                                            #:tg{:node-27367 #:tg{:node-27367 {:count 1 :t 0 :id 5}}},
-                                            :tg/entity {true #:tg{:node-27367 {:count 1 :t 0 :id 6}}},
-                                            :value {"01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9" #:tg{:node-27367 {:count 1 :t 0 :id 1}}},
-                                            :type {"sha256" #:tg{:node-27367 {:count 1 :t 0 :id 7}}},
-                                            :id {"4f390192" #:tg{:node-27367 {:count 1 :t 0 :id 8}}}},
-                                      :osp {:tg/node-27367 #:tg{:node-27367 #:db{:ident {:count 1 :t 0 :id 9}}},
-                                            true #:tg{:node-27367 #:tg{:entity {:count 1 :t 0 :id 10}}},
+                                            #:tg{:node-27367 #:tg{:node-27367 {:count 1 :t 0 :id 1}}},
+                                            :tg/entity {true #:tg{:node-27367 {:count 1 :t 0 :id 2}}},
+                                            :value {"01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9" #:tg{:node-27367 {:count 1 :t 0 :id 3}}},
+                                            :type {"sha256" #:tg{:node-27367 {:count 1 :t 0 :id 4}}},
+                                            :id {"4f390192" #:tg{:node-27367 {:count 1 :t 0 :id 5}}}},
+                                      :osp {:tg/node-27367 #:tg{:node-27367 #:db{:ident {:count 1 :t 0 :id 1}}},
+                                            true #:tg{:node-27367 #:tg{:entity {:count 1 :t 0 :id 2}}},
                                             "01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9"
-                                            #:tg{:node-27367 {:value {:count 1 :t 0 :id 11}}},
-                                            "sha256" #:tg{:node-27367 {:type {:count 1 :t 0 :id 12}}},
-                                            "4f390192" #:tg{:node-27367 {:id {:count 1 :t 0 :id 13}}}}
-                                      :next-stmt-id 14}
+                                            #:tg{:node-27367 {:value {:count 1 :t 0 :id 3}}},
+                                            "sha256" #:tg{:node-27367 {:type {:count 1 :t 0 :id 4}}},
+                                            "4f390192" #:tg{:node-27367 {:id {:count 1 :t 0 :id 5}}}}
+                                      :next-stmt-id 6}
         id "verdict:AMP File Reputation:4f390192"
         m {:type "verdict",
            :disposition 2,

--- a/test/asami/entities/test_entity.cljc
+++ b/test/asami/entities/test_entity.cljc
@@ -403,23 +403,24 @@
 (deftest test-multi-update
   (let [graph
         #asami.multi_graph.MultiGraph{:spo #:tg{:node-27367
-                                                 {:db/ident #:tg{:node-27367 {:count 1 :tx 0}},
-                                                  :tg/entity {true {:count 1 :tx 0}},
-                                                  :value {"01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9" {:count 1 :tx 0}},
-                                                  :type {"sha256" {:count 1 :tx 0}},
-                                                  :id {"4f390192" {:count 1 :tx 0}}}},
+                                                {:db/ident #:tg{:node-27367 {:count 1 :t 0 :id 1}},
+                                                 :tg/entity {true {:count 1 :t 0 :id 2}},
+                                                 :value {"01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9" {:count 1 :t 0 :id 1}},
+                                                 :type {"sha256" {:count 1 :t 0 :id 3}},
+                                                 :id {"4f390192" {:count 1 :t 0 :id 4}}}},
                                       :pos {:db/ident
-                                            #:tg{:node-27367 #:tg{:node-27367 {:count 1 :tx 0}}},
-                                            :tg/entity {true #:tg{:node-27367 {:count 1 :tx 0}}},
-                                            :value {"01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9" #:tg{:node-27367 {:count 1 :tx 0}}},
-                                            :type {"sha256" #:tg{:node-27367 {:count 1 :tx 0}}},
-                                            :id {"4f390192" #:tg{:node-27367 {:count 1 :tx 0}}}},
-                                      :osp {:tg/node-27367 #:tg{:node-27367 #:db{:ident {:count 1 :tx 0}}},
-                                            true #:tg{:node-27367 #:tg{:entity {:count 1 :tx 0}}},
+                                            #:tg{:node-27367 #:tg{:node-27367 {:count 1 :t 0 :id 5}}},
+                                            :tg/entity {true #:tg{:node-27367 {:count 1 :t 0 :id 6}}},
+                                            :value {"01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9" #:tg{:node-27367 {:count 1 :t 0 :id 1}}},
+                                            :type {"sha256" #:tg{:node-27367 {:count 1 :t 0 :id 7}}},
+                                            :id {"4f390192" #:tg{:node-27367 {:count 1 :t 0 :id 8}}}},
+                                      :osp {:tg/node-27367 #:tg{:node-27367 #:db{:ident {:count 1 :t 0 :id 9}}},
+                                            true #:tg{:node-27367 #:tg{:entity {:count 1 :t 0 :id 10}}},
                                             "01468b1d3e089985a4ed255b6594d24863cfd94a647329c631e4f4e52759f8a9"
-                                            #:tg{:node-27367 {:value {:count 1 :tx 0}}},
-                                            "sha256" #:tg{:node-27367 {:type {:count 1 :tx 0}}},
-                                            "4f390192" #:tg{:node-27367 {:id {:count 1 :tx 0}}}}}
+                                            #:tg{:node-27367 {:value {:count 1 :t 0 :id 11}}},
+                                            "sha256" #:tg{:node-27367 {:type {:count 1 :t 0 :id 12}}},
+                                            "4f390192" #:tg{:node-27367 {:id {:count 1 :t 0 :id 13}}}}
+                                      :next-stmt-id 14}
         id "verdict:AMP File Reputation:4f390192"
         m {:type "verdict",
            :disposition 2,


### PR DESCRIPTION
Closes https://github.com/threatgrid/asami/issues/201

Adds statement ids to the multi-index (exactly like https://github.com/threatgrid/asami/pull/204).

Transaction ids were already being stored as `tx`, this just updates that key to`t` for consistency.