### PR TITLE
Relaxed disjunction

### DIFF
--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -343,17 +343,19 @@
     (with-meta
       ;; Does distinct create a scaling issue?
       (*select-distinct*
-       ;; For each result sequence, results, of spread with columns
+       ;; For each result sequence `results` of `spread` with columns
        ;; that are not equal to result-cols, reorganize the elements
-       ;; of results such that they align with result-cols.
+       ;; of `results` such that they align with `result-cols`.
        (sequence 
         (comp (map (fn [results cols]
                      (if (= cols result-cols)
                        results
                        (let [cols-index (index cols)
                              ;; Build a function which maps each
-                             ;; element of a result to its location in
-                             ;; result-cols.
+                             ;; element of a `result` to its location in
+                             ;; `result-cols`.
+                             ;; For any column that appears in `result-cols`
+                             ;; but not the `results`, pad with a `nil`.
                              reorganize (apply juxt (map (fn [col]
                                                            (if-some [i (get cols-index col)]
                                                              (fn [result] (nth result i))

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -395,8 +395,8 @@
 (def operators
   {'not {:left-join minus}
    'NOT {:left-join minus}
-   'or {:left-join #'disjunction}
-   'OR {:left-join #'disjunction}
+   'or {:left-join disjunction}
+   'OR {:left-join disjunction}
    'and {:left-join conjunction}
    'AND {:left-join conjunction}
    'optional {:left-join optional}

--- a/src/asami/query.cljc
+++ b/src/asami/query.cljc
@@ -915,9 +915,8 @@
                            [[(first inputs)] (rest inputs)])
         options (-> (apply hash-map options) (assoc :query-plan plan?))
         [bindings default-graph] (create-bindings in inputs)
-        graph (or default-graph empty-graph)
-        project-fn projection/project]
+        graph (or default-graph empty-graph)]
     (if (seq (filter planner/aggregate-form? find))
-      (aggregate-query find bindings with where graph project-fn options)
+      (aggregate-query find bindings with where graph projection/project options)
       (binding [*select-distinct* (if all identity distinct)]
-        (execute-query find where bindings graph project-fn options)))))
+        (execute-query find where bindings graph projection/project options)))))

--- a/test/asami/core_query_test.cljc
+++ b/test/asami/core_query_test.cljc
@@ -284,7 +284,13 @@
                 st)
           r4 (q '[:find ?observable
                   :where (or [?observable :value "ilo.pl"]
-                             [?observable :value "nonexistent"])] st)]
+                             [?observable :value "nonexistent"])]
+                st)
+          r5 (q '{:find [?id]
+                  :where
+                  [(or [?observable :value ?value]
+                       [?sighting :id ?id])]}
+                st)]
       (is (= #{[ver1 "domain" "cisco.com"]
                [sight1 "ip" "72.163.4.161"]}
              (set r1)))
@@ -294,7 +300,12 @@
       (is (= #{["verdict-1" "domain" "cisco.com"]
                ["sighting-1" "ip" "72.163.4.161"]}
              (set r3)))
-      (is (= [[o3]] r4)))))
+      (is (= [[o3]] r4))
+      (is (= #{[nil]
+               ["verdict-1"]
+               ["sighting-1"]
+               ["other-1"]}
+             (set r5))))))
 
 
 (let [b1 (nn)

--- a/test/asami/core_query_test.cljc
+++ b/test/asami/core_query_test.cljc
@@ -286,7 +286,7 @@
                   :where (or [?observable :value "ilo.pl"]
                              [?observable :value "nonexistent"])]
                 st)
-          r5 (q '{:find [?id]
+          r5 (q '{:find [?id ?value]
                   :where
                   [(or [?observable :value ?value]
                        [?sighting :id ?id])]}
@@ -301,12 +301,13 @@
                ["sighting-1" "ip" "72.163.4.161"]}
              (set r3)))
       (is (= [[o3]] r4))
-      (is (= #{[nil]
-               ["verdict-1"]
-               ["sighting-1"]
-               ["other-1"]}
+      (is (= #{[nil "ilo.pl"]
+               [nil "cisco.com"]
+               [nil "72.163.4.161"]
+               ["verdict-1" nil]
+               ["sighting-1" nil]
+               ["other-1" nil]}
              (set r5))))))
-
 
 (let [b1 (nn)
       b2 (nn)

--- a/test/asami/query_internals_test.cljc
+++ b/test/asami/query_internals_test.cljc
@@ -296,9 +296,8 @@
           with []
           where '[[?a :p ?b] [?a :p2 ?c]]
           graph (assert-data empty-graph agg-data)
-          project-fn internal/project-args
 
-          r (aggregate-query find bindings with where graph project-fn {})]
+          r (aggregate-query find bindings with where graph internal/project-args {})]
       (is (= '[?a ?b ?count-c] (:cols (meta r))))
       (is (= [[:a "first" 3] [:b "second" 5]] r)))
 
@@ -307,9 +306,8 @@
           with []
           where '[[?a :p ?c]]
           graph (assert-data empty-graph agg-data)
-          project-fn internal/project-args
 
-          r (aggregate-query find bindings with where graph project-fn {})]
+          r (aggregate-query find bindings with where graph internal/project-args {})]
       (is (= '[?count-c] (:cols (meta r))))
       (is (= [[2]] r)))))
 

--- a/test/asami/query_internals_test.cljc
+++ b/test/asami/query_internals_test.cljc
@@ -296,7 +296,7 @@
           with []
           where '[[?a :p ?b] [?a :p2 ?c]]
           graph (assert-data empty-graph agg-data)
-          project-fn internal/project-args #_(partial project internal/project-args)
+          project-fn internal/project-args
 
           r (aggregate-query find bindings with where graph project-fn {})]
       (is (= '[?a ?b ?count-c] (:cols (meta r))))
@@ -307,7 +307,7 @@
           with []
           where '[[?a :p ?c]]
           graph (assert-data empty-graph agg-data)
-          project-fn internal/project-args #_(partial project internal/project-args)
+          project-fn internal/project-args
 
           r (aggregate-query find bindings with where graph project-fn {})]
       (is (= '[?count-c] (:cols (meta r))))

--- a/test/asami/query_internals_test.cljc
+++ b/test/asami/query_internals_test.cljc
@@ -210,12 +210,7 @@
                       {:cols '[?e]})
         r1 (disjunction graph part-result '(or [?e :px ?v] [?e :py ?v]))]
     (is (= '[?e ?v] (:cols (meta r1))))
-    (is (= [[:a :m] [:b :o] [:a :n] [:c :p]] r1))
-    (is (thrown-with-msg?
-         ExceptionInfo
-         #"Alternate sides of OR clauses may not contain different vars"
-         (disjunction graph part-result '(or [?e :px ?v] [?e :py ?w]))))))
-
+    (is (= [[:a :m] [:b :o] [:a :n] [:c :p]] r1))))
 
 (deftest test-result-label
   "Tests the result-label function, which renames aggregates to addressable labels"
@@ -301,7 +296,7 @@
           with []
           where '[[?a :p ?b] [?a :p2 ?c]]
           graph (assert-data empty-graph agg-data)
-          project-fn (partial project internal/project-args)
+          project-fn internal/project-args #_(partial project internal/project-args)
 
           r (aggregate-query find bindings with where graph project-fn {})]
       (is (= '[?a ?b ?count-c] (:cols (meta r))))
@@ -312,7 +307,7 @@
           with []
           where '[[?a :p ?c]]
           graph (assert-data empty-graph agg-data)
-          project-fn (partial project internal/project-args)
+          project-fn internal/project-args #_(partial project internal/project-args)
 
           r (aggregate-query find bindings with where graph project-fn {})]
       (is (= '[?count-c] (:cols (meta r))))


### PR DESCRIPTION
This patch relaxes the requirement for the operands of a disjunction to have equivalent sets of unbound variables.

Example:
```clj
(asami/q '{:find [?name ?e2 ?e3]
           :where [(or [?e2 :name ?name]
                       [?e3 :name ?name])]}
         (asami/db location-conn))
;; =>
(["Falls Church" :tg/node-19487 nil]
 ["Arlington" :tg/node-19486 nil]
 ,,,
 ["Falls Church" nil :tg/node-19487]
 ,,,
 ["Arlington" nil :tg/node-19486])
```