### PR TITLE
Datoms

### DIFF
--- a/src/asami/common_index.cljc
+++ b/src/asami/common_index.cljc
@@ -2,7 +2,8 @@
 and multigraph implementations."
       :author "Paula Gearon"}
     asami.common-index
-  (:require [asami.graph :refer [Graph graph-add graph-delete graph-diff resolve-triple count-triple broad-node-type?]]
+  (:require [asami.datom :as datom :refer [->Datom]]
+            [asami.graph :refer [Graph graph-add graph-delete graph-diff resolve-triple count-triple broad-node-type?]]
             [asami.internal :as internal]
             [zuko.schema :as st]
             [clojure.set :as set]
@@ -18,14 +19,16 @@ and multigraph implementations."
         asserts (transient a)
         retracts (transient r)
         new-graph (as-> graph gr
-                    (reduce (fn [acc [s p o :as triple]]
+                    (reduce (fn [acc [s p o]]
                               (let [ad (graph-delete acc s p o)]
-                                (when-not (identical? ad acc) (conj! retracts triple))
+                                (when-not (identical? ad acc)
+                                  (conj! retracts (->Datom s p o tx-id false)))
                                 ad))
                             gr retractions)
-                    (reduce (fn [acc [s p o :as triple]]
+                    (reduce (fn [acc [s p o]]
                               (let [aa (graph-add acc s p o tx-id)]
-                                (when-not (identical? aa acc) (conj! asserts triple))
+                                (when-not (identical? aa acc)
+                                  (conj! asserts (->Datom s p o tx-id true)))
                                 aa))
                             gr assertions))]
     (vreset! generated-data [(persistent! asserts) (persistent! retracts)])

--- a/src/asami/core.cljc
+++ b/src/asami/core.cljc
@@ -5,7 +5,6 @@
               [asami.memory :as memory]
               #?(:clj [asami.durable.store :as durable])  ;; TODO: make this available to CLJS when ready
               [asami.query :as query]
-              [asami.datom :as datom :refer [->Datom]]
               [asami.graph :as gr]
               [asami.entities :as entities]
               [asami.entities.general :refer [GraphType]]
@@ -148,13 +147,13 @@
                      (s/optional-key :update-fn) (s/pred fn?)}
                     [s/Any]))
 
-(s/defn transact
+(s/defn transact-async
   ;; returns a deref'able object that derefs to:
   ;; {:db-before DatabaseType
   ;;  :db-after DatabaseType
   ;;  :tx-data [datom/DatomType]
   ;;  :tempids {s/Any s/Any}}
-  "Updates a database. This is currently synchronous, but returns a future or delay for compatibility with Datomic.
+  "Updates a database.
    connection: The connection to the database to be updated.
    tx-info: This is either a seq of items to be transacted, or a map.
             If this is a map, then a :tx-data value will contain the same type of seq that tx-info may have.
@@ -186,14 +185,7 @@
                  {:db-before db-before
                   :db-after db-after}))
              (fn []
-               (let [tx-id (storage/next-tx connection)
-                     as-datom (fn [assert? [e a v]] (->Datom e a v tx-id assert?))
-                     ;; function to convert assertions and retractions into a seq of datoms
-                     build-datoms (fn [assertions retractions]
-                                    (concat
-                                     (map (partial as-datom false) retractions)
-                                     (map (partial as-datom true) assertions)))
-                     current-db (storage/db connection)
+               (let [current-db (storage/db connection)
                      ;; single maps should not be passed in, but if they are then wrap them
                      seq-wrapper (fn [x] (if (map? x) [x] x))
                      ;; volatiles to capture data for the user
@@ -219,13 +211,67 @@
                      [triples retracts] (deref generated-data)]
                  {:db-before db-before
                   :db-after db-after
-                  :tx-data (build-datoms triples retracts)
+                  :tx-data (concat retracts triples)
                   :tempids @vtempids})))]
     #?(:clj (CompletableFuture/supplyAsync (reify Supplier (get [_] (op)))
                                            (or executor clojure.lang.Agent/soloExecutor))
        :cljs (let [d (delay (op))]
                (force d)
                d))))
+
+;; set a generous default transaction timeout of 100 seconds 
+#?(:clj (def ^:const default-tx-timeout 100000))
+
+#?(:clj
+   (defn get-timeout
+     "Retrieves the timeout value to use in ms"
+     []
+     (or (System/getProperty "asami.txTimeoutMsec")
+         (System/getProperty "datomic.txTimeoutMsec")
+         default-tx-timeout)))
+
+#?(:clj
+   (s/defn transact
+     "This returns a completed future with the data from a transaction.
+      See the documentation for transact-async for full details on arguments.
+      If the transaction times out, the call to transact will throw an ExceptionInfo exception.
+      The default is 100 seconds
+
+      The result derefs to a map of:
+       :db-before database value before the transaction
+       :db-after database value after the transaction
+       :tx-data a sequence of the transacted datom operations
+       :tempids a map of temporary id values and the db identifiers that were allocated for them}"
+     ;; returns a deref'able object that derefs to:
+     ;; {:db-before DatabaseType
+     ;;  :db-after DatabaseType
+     ;;  :tx-data [datom/DatomType]
+     ;;  :tempids {s/Any s/Any}}
+     [connection :- ConnectionType
+      tx-info :- TransactData]
+     (let [transact-future (transact-async connection tx-info)
+           timeout (get-timeout)]
+       (when (= ::timeout (deref transact-future timeout ::timeout))
+         (throw (ex-info "Transaction timeout" {:timeout timeout})))
+       transact-future))
+
+   :cljs
+   (s/defn transact
+     "This is a thin wrapper around the transact-async function.
+      TODO: convert this to a promise-based approach for the async implementation
+      See the documentation for transact-async for full details on arguments.
+      returns a deref'able object that derefs to a map of:
+       :db-before database value before the transaction
+       :db-after database value after the transaction
+       :tx-data a sequence of the transacted datom operations
+       :tempids a map of temporary id values and the db identifiers that were allocated for them}"
+     ;; {:db-before DatabaseType
+     ;;  :db-after DatabaseType
+     ;;  :tx-data [datom/DatomType]
+     ;;  :tempids {s/Any s/Any}}
+     [connection :- ConnectionType
+      tx-info :- TransactData]
+     (transact-async connection tx-info)))
 
 (defn- graphs-of
   "Converts Database objects to the graph that they wrap. Other arguments are returned unmodified."

--- a/src/asami/durable/store.cljc
+++ b/src/asami/durable/store.cljc
@@ -237,10 +237,14 @@
                        (let [[asserts retracts] (generator-fn graph)]
                          (graph/graph-transact graph tx-id asserts retracts updates!))))))
 
+(s/defn get-url* :- s/Str
+  [{:keys [name]} :- ConnectionType]
+  (str "asami:local://" name))
 
 (defrecord DurableConnection [name tx-manager grapha nodea lock]
   storage/Connection
   (get-name [this] name)
+  (get-url [this] (get-url* this))
   (next-tx [this] (common/tx-count tx-manager))
   (db [this] (db* this))
   (delete-database [this] (delete-database* this))

--- a/src/asami/durable/store.cljc
+++ b/src/asami/durable/store.cljc
@@ -1,7 +1,7 @@
 (ns ^{:doc "The implements the Block storage version of a Graph/Database/Connection"
       :author "Paula Gearon"}
     asami.durable.store
-  (:require [asami.storage :as storage :refer [ConnectionType DatabaseType]]
+  (:require [asami.storage :as storage :refer [ConnectionType DatabaseType UpdateData]]
             [asami.graph :as graph]
             [asami.internal :as i :refer [now instant? long-time]]
             [asami.durable.common :as common
@@ -225,15 +225,17 @@
   "Removes a series of tuples from the latest graph, and asserts new tuples into the graph.
    Updates the connection to the new graph."
   ([conn :- ConnectionType
+    updates! :- UpdateData
     asserts :- [Triple]   ;; triples to insert
     retracts :- [Triple]] ;; triples to remove
-   (transact-update* conn (fn [graph tx-id] (graph/graph-transact graph tx-id asserts retracts))))
+   (transact-update* conn (fn [graph tx-id] (graph/graph-transact graph tx-id asserts retracts updates!))))
   ([conn :- ConnectionType
+    updates! :- UpdateData
     generator-fn]
    (transact-update* conn
                      (fn [graph tx-id]
                        (let [[asserts retracts] (generator-fn graph)]
-                         (graph/graph-transact graph tx-id asserts retracts))))))
+                         (graph/graph-transact graph tx-id asserts retracts updates!))))))
 
 
 (defrecord DurableConnection [name tx-manager grapha nodea lock]
@@ -244,8 +246,8 @@
   (delete-database [this] (delete-database* this))
   (release [this] (release* this))
   (transact-update [this update-fn] (transact-update* this update-fn))
-  (transact-data [this asserts retracts] (transact-data* this asserts retracts))
-  (transact-data [this generator-fn] (transact-data* this generator-fn))
+  (transact-data [this updates! asserts retracts] (transact-data* this updates! asserts retracts))
+  (transact-data [this updates! generator-fn] (transact-data* this updates! generator-fn))
   common/Lockable
   (lock! [this] #?(:clj (.lock ^Lock lock)))
   (unlock! [this] #?(:clj (.unlock ^Lock lock))))

--- a/src/asami/graph.cljc
+++ b/src/asami/graph.cljc
@@ -12,7 +12,10 @@
   (new-graph [this] "Creates an empty graph of the same type")
   (graph-add [this subj pred obj] [this subj pred obj tx] "Adds triples to the graph")
   (graph-delete [this subj pred obj] "Removes triples from the graph")
-  (graph-transact [this tx-id assertions retractions] "Bulk operation to add and remove multiple statements in a single operation")
+  (graph-transact
+    [this tx-id assertions retractions]
+    [this tx-id assertions retractions generated]
+    "Bulk operation to add and remove multiple statements in a single operation")
   (graph-diff [this other] "Returns all subjects that have changed in this graph, compared to other")
   (resolve-triple [this subj pred obj] "Resolves patterns from the graph, and returns unbound columns only")
   (count-triple [this subj pred obj] "Resolves patterns from the graph, and returns the size of the resolution"))

--- a/src/asami/index.cljc
+++ b/src/asami/index.cljc
@@ -100,9 +100,9 @@
         (log/trace "statement did not exist")
         this)))
   (graph-transact [this tx-id assertions retractions]
-    (as-> this graph
-      (reduce (fn [acc [s p o]] (graph-delete acc s p o)) graph retractions)
-      (reduce (fn [acc [s p o]] (graph-add acc s p o tx-id)) graph assertions)))
+    (common/graph-transact this tx-id assertions retractions (volatile! [[] [] {}])))
+  (graph-transact [this tx-id assertions retractions generated-data]
+    (common/graph-transact this tx-id assertions retractions generated-data))
   (graph-diff [this other]
     (when-not (= (type this) (type other))
       (throw (ex-info "Unable to compare diffs between graphs of different types" {:this this :other other})))

--- a/src/asami/multi_graph.cljc
+++ b/src/asami/multi_graph.cljc
@@ -132,9 +132,9 @@ allow rules to successfully use this graph type."
         (log/trace "statement did not exist")
         this)))
   (graph-transact [this tx-id assertions retractions]
-    (as-> this graph
-      (reduce (fn [acc [s p o]] (graph-delete acc s p o)) graph retractions)
-      (reduce (fn [acc [s p o]] (graph-add acc s p o tx-id)) graph assertions)))
+    (common/graph-transact this tx-id assertions retractions (volatile! [[] [] {}])))
+  (graph-transact [this tx-id assertions retractions generated-data]
+    (common/graph-transact this tx-id assertions retractions generated-data))
   (graph-diff [this other]
     (when-not (= (type this) (type other))
       (throw (ex-info "Unable to compare diffs between graphs of different types" {:this this :other other})))

--- a/src/asami/storage.cljc
+++ b/src/asami/storage.cljc
@@ -14,8 +14,8 @@
   (transact-update [this update-fn] "Updates a graph in the database with the provided function.
                                      Function args are connection and transaction-id")
   (transact-data
-    [this asserts retracts]
-    [this generator-fn] "Updates the database with provided data"))
+    [this updates! asserts retracts]
+    [this updates! generator-fn] "Updates the database with provided data"))
 
 (defprotocol Database
   (as-of [this t] "Retrieves a database as of a given moment, inclusive")
@@ -25,6 +25,10 @@
   (since-t [this] "Returns the since point for a database")
   (graph [this] "Returns the internal graph for the database")
   (entity [this id] [this id nested?] "Returns an entity for an identifier"))
+
+(def UpdateData (s/pred #(and (instance? #?(:clj clojure.lang.Volatile :cljs Volatile) %)
+                              (vector? (deref %))
+                              (= 2 (count (deref %))))))
 
 (def DatabaseType (s/pred #(satisfies? Database %)))
 (def ConnectionType (s/pred #(satisfies? Connection %)))

--- a/src/asami/storage.cljc
+++ b/src/asami/storage.cljc
@@ -6,6 +6,7 @@
 
 (defprotocol Connection
   (get-name [this] "Retrieves the name of the database")
+  (get-url [this] "Retrieves the url of the database. Based on the name.")
   (next-tx [this] "Returns the next transaction ID that this connection will use")
   (get-lock [this] "Returns a lock that ensures that this Connection can only be updated by a single thread at a time")
   (db [this] "Retrieves the latest database from this connection")

--- a/test/asami/api_test.cljc
+++ b/test/asami/api_test.cljc
@@ -706,6 +706,24 @@
       (delete-database db-io)
       (delete-database db-new))))
 
+(deftest test-database-delete
+  (testing "Are deleted memory databases cleared"
+    (let [db-name "asami:mem://test-del"
+          conn (connect db-name)
+          {d :db-after} @(transact conn {:tx-data io-entities})
+          r (set (q '[:find ?e ?a ?v :where [?e ?a ?v]] d))]
+      (is (= 13 (count r)))
+
+      (delete-database db-name)
+
+      (let [d2 (db conn)
+            r2 (set (q '[:find ?e ?a ?v :where [?e ?a ?v]] d2))
+            r3 (set (q '[:find ?e ?a ?v :where [?e ?a ?v]] conn))
+            r-old (set (q '[:find ?e ?a ?v :where [?e ?a ?v]] d))]
+        (is (empty? r2))
+        (is (empty? r3))
+        (is (= 13 (count r-old)))))))
+
 (deftest test-update-unowned
   (testing "Doing an update on an attribute that references a top level entity"
     (let [c (connect "asami:mem://testupdate")

--- a/test/asami/api_test.cljc
+++ b/test/asami/api_test.cljc
@@ -164,7 +164,7 @@
     (is (= 2 (count (q '[:find ?e ?a ?v :where [?e ?a ?v]] (:db-after r)))))
     (let [r2 @(transact c {:tx-data [[:db/retract :mem/node-1 :property "value"]
                                      [:db/retract :mem/node-1 :property "missing"]]})]
-      (is (= 2 (count (:tx-data r2))))
+      (is (= 1 (count (:tx-data r2))))
       (is (= [[:mem/node-2 :property "other"]]
              (q '[:find ?e ?a ?v :where [?e ?a ?v]] (:db-after r2)))))))
 
@@ -250,7 +250,8 @@
         {:keys [tempids tx-data] :as r} @(transact c [data])
         one (tempids -1)
         d (db c)]
-    (is (= 20 (count tx-data)))
+    ;; nil is contained twice, so 19 statements, rather than the 20 inserted
+    (is (= 19 (count tx-data)))
     (is (= 2 (count (filter #(and (= :tg/first (nth % 1)) (= :tg/nil (nth % 2))) tx-data))))
     (is (= {:name  "Home"
             :address nil

--- a/test/asami/api_test.cljc
+++ b/test/asami/api_test.cljc
@@ -1,7 +1,7 @@
 (ns asami.api-test
   "Tests the public query functionality"
-  (:require [asami.core :refer [q show-plan create-database connect db transact
-                                entity as-of since import-data export-data delete-database]]
+  (:require [asami.core :as a :refer [q show-plan create-database connect db transact
+                                      entity as-of since import-data export-data delete-database]]
             [asami.index :as i]
             [asami.graph :as graph]
             [asami.multi-graph :as m]
@@ -722,7 +722,14 @@
             r-old (set (q '[:find ?e ?a ?v :where [?e ?a ?v]] d))]
         (is (empty? r2))
         (is (empty? r3))
-        (is (= 13 (count r-old)))))))
+        (is (= 13 (count r-old))))
+
+      (is (nil? (get @a/connections db-name)))
+      (let [{dx :db-after} @(transact conn {:tx-triples [[:mem/node-1 :property "value"]
+                                                         [:mem/node-2 :property "other"]]})
+            rx (q '[:find ?e ?a ?v :where [?e ?a ?v]] dx)]
+        (is (identical? conn (get @a/connections db-name)))
+        (is (= 2 (count rx)))))))
 
 (deftest test-update-unowned
   (testing "Doing an update on an attribute that references a top level entity"

--- a/test/asami/durable/api_test.cljc
+++ b/test/asami/durable/api_test.cljc
@@ -173,7 +173,7 @@
     (is (= 2 (count (q '[:find ?e ?a ?v :where [?e ?a ?v]] (:db-after r)))))
     (let [r2 @(transact c {:tx-data [[:db/retract :mem/node-1 :property "value"]
                                      [:db/retract :mem/node-1 :property "missing"]]})]
-      (is (= 2 (count (:tx-data r2))))
+      (is (= 1 (count (:tx-data r2))))
       (is (= [[:mem/node-2 :property "other"]]
              (q '[:find ?e ?a ?v :where [?e ?a ?v]] (:db-after r2))))))
   (delete-database "asami:local://testr")
@@ -232,7 +232,8 @@
         {:keys [tempids tx-data] :as r} @(transact c [data])
         one (tempids -1)
         d (db c)]
-    (is (= 20 (count tx-data)))
+    ;; nil is contained twice, so 19 statements, rather than the 20 inserted
+    (is (= 19 (count tx-data)))
     (is (= 2 (count (filter #(and (= :tg/first (nth % 1)) (= :tg/nil (nth % 2))) tx-data))))
     (is (= {:name  "Home"
             :address nil


### PR DESCRIPTION
Datom results from transactions are now restricted to only the changes made.

Deleting in-memory database connections now clears them out. Reusing them will reattach them to the registry